### PR TITLE
Separate LDLIBS and LDFLAGS.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 
 CC:=gcc
 CFLAGS:=-g -Wall -Wextra -Wmissing-prototypes -Wformat-security -Wno-unused-parameter
-LDFLAGS:=-lm
+LDFLAGS:=
+LDLIBS:=-lm
 
 all: stamp
 
@@ -19,7 +20,7 @@ bmpsuite.o: bmpsuite.c
 	$(CC) $(CFLAGS) -c -o $@ $<
 
 $(BMPSUITE): bmpsuite.o
-	$(CC) $(LDFLAGS) -o $@ $^
+	$(CC) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
 stamp: $(BMPSUITE)
 	./$(BMPSUITE)


### PR DESCRIPTION
[The GNU make manual](https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html) explains how `LDFLAGS` and `LDLIBS` ought to be separated. 

Without this change gcc 9.2.1 will complain about undefined references like so:

```
/usr/bin/ld: bmpsuite.o: in function `srgb_to_linear':
/home/user/src/bmpsuite/bmpsuite.c:193: undefined reference to `pow'
/usr/bin/ld: bmpsuite.o: in function `linear_to_srgb':
/home/suer/src/bmpsuite/bmpsuite.c:203: undefined reference to `pow'
/usr/bin/ld: bmpsuite.o: in function `quantize':
/home/user/src/bmpsuite/bmpsuite.c:328: undefined reference to `floor'
collect2: error: ld returned 1 exit status
```

This proposed commit fixes the problem. If you need me to change it somehow, 
please let me know. :)