### PR TITLE
Add b/pal4used13.bmp and b/pal4used0.bmp

### DIFF
--- a/html/bmpsuite.html
+++ b/html/bmpsuite.html
@@ -858,6 +858,22 @@ level of support for it is arguably not important.</p>
  </tr>
 
  <tr>
+  <td class=bad>b/pal4used0.bmp</td>
+  <td>3</td>
+  <td class=b>N/A</td>
+  <td class=b><img src="../b/pal4used0.bmp"></td>
+  <td>Paletted image with 12 palette colors and 4 bits/pixel, but with biClrUsed set to 0 which implies 2<sup>4</sup> or 16 colors in the palette.</td>
+ </tr>
+
+ <tr>
+  <td class=bad>b/pal4used13.bmp</td>
+  <td>3</td>
+  <td class=b>N/A</td>
+  <td class=b><img src="../b/pal4used13.bmp"></td>
+  <td>Paletted image with 12 palette colors and 4 bits/pixel, but with biClrUsed set to 13.</td>
+ </tr>
+
+ <tr>
   <td class=bad>b/pal8badindex.bmp</td>
   <td>3</td>
   <td class=b>N/A</td>


### PR DESCRIPTION
pal4used13 has 12 colors in the color palette but biClrUsed is set to 13

pal4used0 has 12 colors in the color palette but biClrUsed is set to 0, which implies 2^4 or 16 colors

Closes #22